### PR TITLE
Add white-label theming, audio, and floor plan controls

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -86,3 +86,53 @@ flex: 1;
 font-weight: 600;
 margin-bottom: 1rem;
 }
+
+.phantomviews-tour-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.phantomviews-tour-settings-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.phantomviews-settings-panel .components-panel__body {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+.phantomviews-repeatable-fieldset {
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  padding: 1rem;
+  border-radius: 10px;
+  margin-top: 1rem;
+  background: rgba(248, 250, 252, 0.8);
+}
+
+.phantomviews-repeatable-fieldset legend {
+  font-weight: 600;
+  padding: 0 0.5rem;
+}
+
+.phantomviews-repeatable-fieldset .components-text-control {
+  margin-bottom: 0.75rem;
+}
+
+.phantomviews-empty-note {
+  margin-top: 1rem;
+  font-style: italic;
+  color: #475569;
+}
+
+.phantomviews-color-input {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  height: 42px;
+  padding: 0;
+  cursor: pointer;
+}

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,46 +1,215 @@
 .phantomviews-tour {
-position: relative;
-overflow: hidden;
-border-radius: 18px;
-box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
-background: #000;
+  --phantomviews-primary: #0f172a;
+  --phantomviews-secondary: #1e293b;
+  --phantomviews-accent: #38bdf8;
+  --phantomviews-font: 'inherit';
+  position: relative;
+  overflow: hidden;
+  border-radius: 18px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
+  background: var(--phantomviews-primary);
+  font-family: var(--phantomviews-font, inherit);
+  color: #fff;
+}
+
+.phantomviews-tour a {
+  color: inherit;
 }
 
 .phantomviews-viewer,
 .phantomviews-viewer canvas {
-width: 100% !important;
-height: 100% !important;
-display: block;
+  width: 100% !important;
+  height: 100% !important;
+  display: block;
+}
+
+.phantomviews-branding-badge {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.92));
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.35);
+  z-index: 5;
+}
+
+.phantomviews-branding-content {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  text-decoration: none;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.phantomviews-branding-content img {
+  max-height: 32px;
+  width: auto;
+  border-radius: 6px;
+}
+
+.phantomviews-audio-controller {
+  position: absolute;
+  left: 1rem;
+  bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.88);
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  box-shadow: 0 18px 45px rgba(8, 47, 73, 0.3);
+  backdrop-filter: blur(12px);
+  z-index: 5;
+}
+
+.phantomviews-audio-label {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+}
+
+.phantomviews-audio-select {
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  border-radius: 8px;
+  padding: 0.35rem 0.65rem;
+  background: rgba(15, 23, 42, 0.6);
+  color: #fff;
+  font-size: 0.9rem;
+}
+
+.phantomviews-audio-player {
+  max-width: 220px;
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 8px;
+}
+
+.phantomviews-floorplan-toggle {
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--phantomviews-accent);
+  color: #0f172a;
+  box-shadow: 0 18px 40px rgba(56, 189, 248, 0.45);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  z-index: 5;
+}
+
+.phantomviews-floorplan-toggle:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 45px rgba(56, 189, 248, 0.55);
+}
+
+.phantomviews-floorplan-panel {
+  position: absolute;
+  right: 1rem;
+  bottom: 4.5rem;
+  width: min(320px, 80vw);
+  max-height: 60vh;
+  overflow-y: auto;
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 18px;
+  padding: 1rem;
+  box-shadow: 0 24px 55px rgba(15, 23, 42, 0.45);
+  transform: translateY(10px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  z-index: 5;
+}
+
+.phantomviews-floorplan-panel.is-open {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.phantomviews-floorplan-item {
+  margin: 0 0 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.phantomviews-floorplan-item img {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
+}
+
+.phantomviews-floorplan-item figcaption {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.9);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .phantomviews-hotspot-tooltip {
-position: absolute;
-background: rgba(15, 23, 42, 0.92);
-color: #fff;
-padding: 0.75rem 1rem;
-border-radius: 12px;
-box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
-transform: translate(-50%, -125%);
-max-width: 260px;
-pointer-events: none;
-opacity: 0;
-transition: opacity 0.2s ease;
+  position: absolute;
+  background: rgba(15, 23, 42, 0.92);
+  color: #fff;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+  transform: translate(-50%, -125%);
+  max-width: 260px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
 }
 
 .phantomviews-hotspot-tooltip.is-visible {
-opacity: 1;
+  opacity: 1;
 }
 
 .phantomviews-hotspot-media iframe {
-width: 320px;
-height: 180px;
-border: none;
-border-radius: 12px;
+  width: 320px;
+  height: 180px;
+  border: none;
+  border-radius: 12px;
+}
+
+.phantomviews-tour-expired {
+  background: linear-gradient(135deg, #0f172a, #1e293b);
+  color: #f8fafc;
+  padding: 2.5rem;
+  border-radius: 18px;
+  text-align: center;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.25);
+  font-size: 1.1rem;
+  line-height: 1.6;
 }
 
 @media (max-width: 768px) {
-.phantomviews-hotspot-media iframe {
-width: 240px;
-height: 135px;
-}
+  .phantomviews-audio-controller {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.65rem 0.75rem;
+  }
+
+  .phantomviews-audio-player {
+    width: 100%;
+  }
+
+  .phantomviews-floorplan-panel {
+    width: calc(100% - 2rem);
+    left: 1rem;
+    right: 1rem;
+  }
+
+  .phantomviews-hotspot-media iframe {
+    width: 240px;
+    height: 135px;
+  }
 }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,7 +1,7 @@
 (function (wp) {
 const { apiFetch, components, element, i18n } = wp;
 const { useState, useEffect } = element;
-const { Button, Card, CardBody, CardHeader, Flex, FlexItem, Notice, Spinner, TextControl, TextareaControl, Panel, PanelBody, SelectControl } = components;
+  const { Button, Card, CardBody, CardHeader, Flex, FlexItem, Notice, Spinner, TextControl, TextareaControl, Panel, PanelBody, SelectControl, ToggleControl, BaseControl } = components;
 const { __ } = i18n;
 
 function LicensePanel({ licenseState, proEnabled, licenseExpiry, onLicenseUpdate }) {
@@ -221,6 +221,242 @@ function LicensePanel({ licenseState, proEnabled, licenseExpiry, onLicenseUpdate
   );
 }
 
+function ColorControl({ label, value, onChange, defaultValue = '#0f172a' }) {
+  return element.createElement(
+    BaseControl,
+    { label },
+    element.createElement('input', {
+      type: 'color',
+      value: value || defaultValue,
+      onChange: (event) => onChange(event.target.value),
+      className: 'phantomviews-color-input',
+    })
+  );
+}
+
+function BrandingSettings({ branding, onChange }) {
+  const updateBranding = (field, value) => {
+    onChange({ ...branding, [field]: value });
+  };
+
+  const modeOptions = [
+    { label: __('Default PhantomViews branding', 'phantomviews'), value: 'default' },
+    { label: __('White-label (use client branding)', 'phantomviews'), value: 'white_label' },
+  ];
+
+  return element.createElement(
+    Panel,
+    { className: 'phantomviews-settings-panel' },
+    element.createElement(
+      PanelBody,
+      { title: __('Branding & White-label', 'phantomviews'), initialOpen: true },
+      element.createElement(SelectControl, {
+        label: __('Branding mode', 'phantomviews'),
+        value: branding.mode || 'default',
+        options: modeOptions,
+        onChange: (value) => updateBranding('mode', value),
+        help: __('Replace PhantomViews branding with custom client assets.', 'phantomviews'),
+      }),
+      element.createElement(TextControl, {
+        label: __('Brand name', 'phantomviews'),
+        value: branding.brand_name || '',
+        onChange: (value) => updateBranding('brand_name', value),
+        help: __('Displayed in the tour badge when white-label mode is enabled.', 'phantomviews'),
+      }),
+      element.createElement(TextControl, {
+        label: __('Brand logo URL', 'phantomviews'),
+        value: branding.brand_logo || '',
+        onChange: (value) => updateBranding('brand_logo', value),
+        placeholder: __('https://example.com/logo.png', 'phantomviews'),
+      }),
+      element.createElement(TextControl, {
+        label: __('Brand link', 'phantomviews'),
+        value: branding.brand_url || '',
+        onChange: (value) => updateBranding('brand_url', value),
+        placeholder: __('https://example.com', 'phantomviews'),
+      })
+    )
+  );
+}
+
+function ThemeSettings({ theme, onChange }) {
+  const updateTheme = (field, value) => {
+    onChange({ ...theme, [field]: value });
+  };
+
+  return element.createElement(
+    Panel,
+    { className: 'phantomviews-settings-panel' },
+    element.createElement(
+      PanelBody,
+      { title: __('Custom theme', 'phantomviews'), initialOpen: false },
+      ColorControl({
+        label: __('Primary color', 'phantomviews'),
+        value: theme.primary_color,
+        onChange: (value) => updateTheme('primary_color', value),
+        defaultValue: '#0f172a',
+      }),
+      ColorControl({
+        label: __('Secondary color', 'phantomviews'),
+        value: theme.secondary_color,
+        onChange: (value) => updateTheme('secondary_color', value),
+        defaultValue: '#1e293b',
+      }),
+      ColorControl({
+        label: __('Accent color', 'phantomviews'),
+        value: theme.accent_color,
+        onChange: (value) => updateTheme('accent_color', value),
+        defaultValue: '#38bdf8',
+      }),
+      element.createElement(TextControl, {
+        label: __('Font family', 'phantomviews'),
+        value: theme.font_family || '',
+        onChange: (value) => updateTheme('font_family', value),
+        placeholder: __('e.g. "Poppins", sans-serif', 'phantomviews'),
+      })
+    )
+  );
+}
+
+function ExpirationSettings({ expiration, onChange }) {
+  const updateExpiration = (field, value) => {
+    onChange({ ...expiration, [field]: value });
+  };
+
+  const isEnabled = !!expiration.enabled;
+
+  return element.createElement(
+    Panel,
+    { className: 'phantomviews-settings-panel' },
+    element.createElement(
+      PanelBody,
+      { title: __('Expirable links', 'phantomviews'), initialOpen: false },
+      element.createElement(ToggleControl, {
+        label: __('Enable expiration date', 'phantomviews'),
+        checked: isEnabled,
+        onChange: (value) => updateExpiration('enabled', value),
+        help: __('Automatically disable public access after the selected date.', 'phantomviews'),
+      }),
+      isEnabled
+        ? element.createElement(TextControl, {
+            label: __('Expires on', 'phantomviews'),
+            value: expiration.expires_at || '',
+            onChange: (value) => updateExpiration('expires_at', value),
+            type: 'datetime-local',
+          })
+        : null
+    )
+  );
+}
+
+function FloorPlanEditor({ floorPlans, onChange }) {
+  const updatePlan = (index, field, value) => {
+    const updated = floorPlans.map((plan, idx) => (idx === index ? { ...plan, [field]: value } : plan));
+    onChange(updated);
+  };
+
+  const addPlan = () => {
+    onChange([...(floorPlans || []), { title: '', image_url: '' }]);
+  };
+
+  const removePlan = (index) => {
+    onChange((floorPlans || []).filter((_, idx) => idx !== index));
+  };
+
+  return element.createElement(
+    Panel,
+    { className: 'phantomviews-settings-panel' },
+    element.createElement(
+      PanelBody,
+      { title: __('Floor plans', 'phantomviews'), initialOpen: false },
+      element.createElement(
+        Button,
+        { variant: 'secondary', onClick: addPlan },
+        __('Add floor plan', 'phantomviews')
+      ),
+      (floorPlans || []).length
+        ? (floorPlans || []).map((plan, index) =>
+            element.createElement(
+              'fieldset',
+              { key: index, className: 'phantomviews-repeatable-fieldset' },
+              element.createElement('legend', null, __('Floor plan', 'phantomviews') + ' #' + (index + 1)),
+              element.createElement(TextControl, {
+                label: __('Title', 'phantomviews'),
+                value: plan.title || '',
+                onChange: (value) => updatePlan(index, 'title', value),
+              }),
+              element.createElement(TextControl, {
+                label: __('Image URL', 'phantomviews'),
+                value: plan.image_url || '',
+                onChange: (value) => updatePlan(index, 'image_url', value),
+                placeholder: __('https://example.com/floorplan.jpg', 'phantomviews'),
+              }),
+              element.createElement(
+                Button,
+                { variant: 'link', isDestructive: true, onClick: () => removePlan(index) },
+                __('Remove', 'phantomviews')
+              )
+            )
+          )
+        : element.createElement('p', { className: 'phantomviews-empty-note' }, __('No floor plans added yet.', 'phantomviews'))
+    )
+  );
+}
+
+function AudioTrackEditor({ audioTracks, onChange }) {
+  const updateTrack = (index, field, value) => {
+    const updated = audioTracks.map((track, idx) => (idx === index ? { ...track, [field]: value } : track));
+    onChange(updated);
+  };
+
+  const addTrack = () => {
+    onChange([...(audioTracks || []), { label: '', url: '' }]);
+  };
+
+  const removeTrack = (index) => {
+    onChange((audioTracks || []).filter((_, idx) => idx !== index));
+  };
+
+  return element.createElement(
+    Panel,
+    { className: 'phantomviews-settings-panel' },
+    element.createElement(
+      PanelBody,
+      { title: __('Audio tracks', 'phantomviews'), initialOpen: false },
+      element.createElement(
+        Button,
+        { variant: 'secondary', onClick: addTrack },
+        __('Add audio track', 'phantomviews')
+      ),
+      (audioTracks || []).length
+        ? (audioTracks || []).map((track, index) =>
+            element.createElement(
+              'fieldset',
+              { key: index, className: 'phantomviews-repeatable-fieldset' },
+              element.createElement('legend', null, __('Audio track', 'phantomviews') + ' #' + (index + 1)),
+              element.createElement(TextControl, {
+                label: __('Label', 'phantomviews'),
+                value: track.label || '',
+                onChange: (value) => updateTrack(index, 'label', value),
+              }),
+              element.createElement(TextControl, {
+                label: __('Audio URL', 'phantomviews'),
+                value: track.url || '',
+                onChange: (value) => updateTrack(index, 'url', value),
+                placeholder: __('https://example.com/audio.mp3', 'phantomviews'),
+              }),
+              element.createElement(
+                Button,
+                { variant: 'link', isDestructive: true, onClick: () => removeTrack(index) },
+                __('Remove', 'phantomviews')
+              )
+            )
+          )
+        : element.createElement('p', { className: 'phantomviews-empty-note' }, __('No audio tracks yet.', 'phantomviews'))
+    )
+  );
+}
+
 function HotspotEditor({ scene, onUpdate }) {
 const [localScene, setLocalScene] = useState(scene);
 
@@ -290,9 +526,9 @@ onChange: (value) => updateHotspot(index, 'media_url', value),
 }
 
 function SceneCard({ scene, onUpdate, onDelete, isPro }) {
-const [localScene, setLocalScene] = useState(scene);
+  const [localScene, setLocalScene] = useState(scene);
 
-useEffect(() => setLocalScene(scene), [scene]);
+  useEffect(() => setLocalScene(scene), [scene]);
 
 const updateField = (field, value) => {
 const updated = { ...localScene, [field]: value };
@@ -335,98 +571,164 @@ __('Delete Scene', 'phantomviews')
 );
 }
 
-function TourEditor({ postId, initialScenes, sceneLimit }) {
-const [scenes, setScenes] = useState(initialScenes || []);
-const [isSaving, setIsSaving] = useState(false);
-const [notice, setNotice] = useState(null);
+function TourEditor({ postId, initialScenes, sceneLimit, initialBranding, initialTheme, initialExpiration, initialFloorPlans, initialAudioTracks }) {
+  const normalizeBoolean = (value) => value === true || value === 'true' || value === '1' || value === 1;
+  const [scenes, setScenes] = useState(initialScenes || []);
+  const [branding, setBranding] = useState({
+    mode: (initialBranding && initialBranding.mode) || 'default',
+    brand_name: (initialBranding && initialBranding.brand_name) || '',
+    brand_logo: (initialBranding && initialBranding.brand_logo) || '',
+    brand_url: (initialBranding && initialBranding.brand_url) || '',
+  });
+  const [theme, setTheme] = useState({
+    primary_color: (initialTheme && initialTheme.primary_color) || '#0f172a',
+    secondary_color: (initialTheme && initialTheme.secondary_color) || '#1e293b',
+    accent_color: (initialTheme && initialTheme.accent_color) || '#38bdf8',
+    font_family: (initialTheme && initialTheme.font_family) || 'inherit',
+  });
+  const [expiration, setExpiration] = useState({
+    enabled: initialExpiration ? normalizeBoolean(initialExpiration.enabled) : false,
+    expires_at: (initialExpiration && initialExpiration.expires_at) || '',
+  });
+  const [floorPlans, setFloorPlans] = useState(initialFloorPlans || []);
+  const [audioTracks, setAudioTracks] = useState(initialAudioTracks || []);
+  const [isSaving, setIsSaving] = useState(false);
+  const [notice, setNotice] = useState(null);
 
-const addScene = () => {
-if (!PhantomViewsAdmin.pro_enabled && scenes.length >= sceneLimit) {
-setNotice({ status: 'warning', text: PhantomViewsAdmin.i18n.sceneLimitReached });
-return;
+  const addScene = () => {
+    if (!PhantomViewsAdmin.pro_enabled && scenes.length >= sceneLimit) {
+      setNotice({ status: 'warning', text: PhantomViewsAdmin.i18n.sceneLimitReached });
+      return;
+    }
+
+    setScenes([
+      ...scenes,
+      {
+        id: 'scene-' + Date.now(),
+        title: '',
+        image_url: '',
+        hotspots: [],
+      },
+    ]);
+  };
+
+  const updateScene = (updatedScene) => {
+    setScenes((prev) => prev.map((scene) => (scene.id === updatedScene.id ? updatedScene : scene)));
+  };
+
+  const deleteScene = (sceneId) => {
+    setScenes((prev) => prev.filter((scene) => scene.id !== sceneId));
+  };
+
+  const saveScenes = () => {
+    setIsSaving(true);
+    setNotice(null);
+
+    apiFetch({
+      path: `phantomviews/v1/tours/${postId}`,
+      method: 'POST',
+      data: {
+        scenes,
+        branding,
+        theme,
+        expiration: { ...expiration, enabled: !!expiration.enabled },
+        floorPlans,
+        audioTracks,
+      },
+    })
+      .then((response) => {
+        setNotice({ status: 'success', text: response.message });
+      })
+      .catch((error) => {
+        setNotice({ status: 'error', text: error.message || __('Failed to save scenes', 'phantomviews') });
+      })
+      .finally(() => setIsSaving(false));
+  };
+
+  return element.createElement(
+    'div',
+    { className: 'phantomviews-tour-editor' },
+    notice ? element.createElement(Notice, { status: notice.status }, notice.text) : null,
+    element.createElement(
+      Flex,
+      { justify: 'flex-end' },
+      element.createElement(
+        Button,
+        { variant: 'primary', onClick: saveScenes, disabled: isSaving },
+        isSaving ? element.createElement(Spinner, null) : PhantomViewsAdmin.i18n.save
+      )
+    ),
+    element.createElement(
+      'div',
+      { className: 'phantomviews-tour-settings-grid' },
+      element.createElement(BrandingSettings, { branding, onChange: setBranding }),
+      element.createElement(ThemeSettings, { theme, onChange: setTheme }),
+      element.createElement(ExpirationSettings, { expiration, onChange: setExpiration }),
+      element.createElement(FloorPlanEditor, { floorPlans, onChange: setFloorPlans }),
+      element.createElement(AudioTrackEditor, { audioTracks, onChange: setAudioTracks })
+    ),
+    element.createElement(
+      Button,
+      { onClick: addScene, variant: 'secondary' },
+      __('Add Scene', 'phantomviews')
+    ),
+    element.createElement(
+      'div',
+      { className: 'phantomviews-scene-list' },
+      scenes.map((scene) =>
+        element.createElement(SceneCard, {
+          key: scene.id,
+          scene,
+          onUpdate: updateScene,
+          onDelete: deleteScene,
+          isPro: PhantomViewsAdmin.pro_enabled,
+        })
+      )
+    )
+  );
 }
 
-setScenes([
-...scenes,
-{
-id: 'scene-' + Date.now(),
-title: '',
-image_url: '',
-hotspots: [],
-},
-]);
+const parseDatasetJSON = (value, fallback) => {
+  if (!value) {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('PhantomViews: Failed to parse dataset value', error);
+    return fallback;
+  }
 };
-
-const updateScene = (updatedScene) => {
-setScenes((prev) => prev.map((scene) => (scene.id === updatedScene.id ? updatedScene : scene)));
-};
-
-const deleteScene = (sceneId) => {
-setScenes((prev) => prev.filter((scene) => scene.id !== sceneId));
-};
-
-const saveScenes = () => {
-setIsSaving(true);
-setNotice(null);
-
-apiFetch({
-path: `phantomviews/v1/tours/${postId}`,
-method: 'POST',
-data: { scenes },
-})
-.then((response) => {
-setNotice({ status: 'success', text: response.message });
-})
-.catch((error) => {
-setNotice({ status: 'error', text: error.message || __('Failed to save scenes', 'phantomviews') });
-})
-.finally(() => setIsSaving(false));
-};
-
-return element.createElement(
-'div',
-{ className: 'phantomviews-tour-editor' },
-notice ? element.createElement(Notice, { status: notice.status }, notice.text) : null,
-element.createElement(
-Flex,
-{ justify: 'flex-end' },
-element.createElement(
-Button,
-{ variant: 'primary', onClick: saveScenes, disabled: isSaving },
-isSaving ? element.createElement(Spinner, null) : PhantomViewsAdmin.i18n.save
-)
-),
-element.createElement(
-Button,
-{ onClick: addScene, variant: 'secondary' },
-__('Add Scene', 'phantomviews')
-),
-element.createElement(
-'div',
-{ className: 'phantomviews-scene-list' },
-scenes.map((scene) =>
-element.createElement(SceneCard, {
-key: scene.id,
-scene,
-onUpdate: updateScene,
-onDelete: deleteScene,
-isPro: PhantomViewsAdmin.pro_enabled,
-})
-)
-)
-);
-}
 
 document.addEventListener('DOMContentLoaded', () => {
-const root = document.getElementById('phantomviews-tour-root');
-if (root) {
-const postId = root.dataset.postId;
-const initialScenes = JSON.parse(root.dataset.scenes || '[]');
-const sceneLimit = parseInt(root.dataset.sceneLimit || '3', 10);
-element.render(element.createElement(TourEditor, { postId, initialScenes, sceneLimit }), root);
-}
+  const root = document.getElementById('phantomviews-tour-root');
+  if (root) {
+    const postId = root.dataset.postId;
+    const initialScenes = parseDatasetJSON(root.dataset.scenes, []);
+    const sceneLimit = parseInt(root.dataset.sceneLimit || '3', 10);
+    const initialBranding = parseDatasetJSON(root.dataset.branding, {});
+    const initialTheme = parseDatasetJSON(root.dataset.theme, {});
+    const initialExpiration = parseDatasetJSON(root.dataset.expiration, {});
+    const initialFloorPlans = parseDatasetJSON(root.dataset.floorPlans, []);
+    const initialAudioTracks = parseDatasetJSON(root.dataset.audioTracks, []);
+    element.render(
+      element.createElement(TourEditor, {
+        postId,
+        initialScenes,
+        sceneLimit,
+        initialBranding,
+        initialTheme,
+        initialExpiration,
+        initialFloorPlans,
+        initialAudioTracks,
+      }),
+      root
+    );
+  }
 
-const licenseRoot = document.getElementById('phantomviews-license-root');
+  const licenseRoot = document.getElementById('phantomviews-license-root');
 if (licenseRoot) {
 element.render(
 element.createElement(LicensePanel, {

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,74 +1,247 @@
 (function () {
-const tours = document.querySelectorAll('.phantomviews-tour');
-if (!tours.length) {
-return;
-}
+  const tours = document.querySelectorAll('.phantomviews-tour');
+  if (!tours.length) {
+    return;
+  }
 
-tours.forEach((container) => {
-const tourId = container.dataset.tourId;
-const dataScript = document.querySelector(`script.phantomviews-data[data-tour-id="${tourId}"]`);
-if (!dataScript) {
-return;
-}
+  const parseTourData = (text) => {
+    if (!text) {
+      return { scenes: [] };
+    }
 
-let scenes = [];
-try {
-scenes = JSON.parse(dataScript.textContent || '[]');
-} catch (error) {
-console.error('PhantomViews: Failed to parse tour data', error);
-return;
-}
+    try {
+      const parsed = JSON.parse(text);
+      if (Array.isArray(parsed)) {
+        return { scenes: parsed };
+      }
+      return parsed || { scenes: [] };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('PhantomViews: Failed to parse tour data', error);
+      return { scenes: [] };
+    }
+  };
 
-if (!Array.isArray(scenes) || !scenes.length) {
-return;
-}
+  const applyTheme = (container, theme = {}) => {
+    const defaults = {
+      primary_color: '#0f172a',
+      secondary_color: '#1e293b',
+      accent_color: '#38bdf8',
+      font_family: 'inherit',
+    };
 
-const viewer = new PANOLENS.Viewer({
-container: container.querySelector('.phantomviews-viewer'),
-controlBar: true,
-autoHideInfospot: false,
-});
+    const resolved = { ...defaults, ...theme };
 
-const sceneMap = new Map();
+    container.style.setProperty('--phantomviews-primary', resolved.primary_color);
+    container.style.setProperty('--phantomviews-secondary', resolved.secondary_color);
+    container.style.setProperty('--phantomviews-accent', resolved.accent_color);
+    container.style.setProperty('--phantomviews-font', resolved.font_family);
+  };
 
-scenes.forEach((scene) => {
-const panorama = new PANOLENS.ImagePanorama(scene.image_url);
+  const renderBranding = (container, branding = {}) => {
+    const mode = branding.mode || 'default';
+    let displayName = branding.brand_name;
+    const logo = branding.brand_logo;
+    const url = branding.brand_url;
 
-if (Array.isArray(scene.hotspots)) {
-scene.hotspots.forEach((hotspot) => {
-const infospot = new PANOLENS.Infospot(350, hotspot.icon_url || undefined);
-infospot.position.set(hotspot.position.x, hotspot.position.y, hotspot.position.z);
-if (hotspot.type === 'link' && hotspot.target_scene && hotspot.target_scene !== scene.id) {
-infospot.addHoverText(hotspot.title || '');
-infospot.addEventListener('click', () => {
-const target = sceneMap.get(hotspot.target_scene);
-if (target) {
-viewer.setPanorama(target.panorama);
-}
-});
-}
+    if (!displayName && mode !== 'white_label') {
+      displayName = 'PhantomViews';
+    }
 
-if (hotspot.type === 'media' && hotspot.media_url) {
-const iframe = document.createElement('iframe');
-iframe.src = hotspot.media_url;
-iframe.setAttribute('allowfullscreen', 'true');
-iframe.classList.add('phantomviews-hotspot-media');
-infospot.addHoverElement(iframe, 220);
-} else if (hotspot.description) {
-infospot.addHoverText(hotspot.description);
-}
+    if (!displayName && !logo) {
+      return;
+    }
 
-panorama.add(infospot);
-});
-}
+    const badge = document.createElement('div');
+    badge.className = 'phantomviews-branding-badge';
 
-sceneMap.set(scene.id, { panorama, scene });
-viewer.add(panorama);
-});
+    const content = url ? document.createElement('a') : document.createElement('span');
+    content.className = 'phantomviews-branding-content';
+    if (url) {
+      content.href = url;
+      content.target = '_blank';
+      content.rel = 'noopener noreferrer';
+    }
 
-const initial = sceneMap.values().next().value;
-if (initial) {
-viewer.setPanorama(initial.panorama);
-}
-});
+    if (logo) {
+      const image = document.createElement('img');
+      image.src = logo;
+      image.alt = displayName || '';
+      image.loading = 'lazy';
+      content.appendChild(image);
+    }
+
+    if (displayName) {
+      const text = document.createElement('span');
+      text.textContent = displayName;
+      content.appendChild(text);
+    }
+
+    badge.appendChild(content);
+    container.appendChild(badge);
+  };
+
+  const renderAudioControls = (container, audioTracks = []) => {
+    const validTracks = audioTracks.filter((track) => track && track.url);
+    if (!validTracks.length) {
+      return;
+    }
+
+    const audioWrapper = document.createElement('div');
+    audioWrapper.className = 'phantomviews-audio-controller';
+
+    const label = document.createElement('span');
+    label.className = 'phantomviews-audio-label';
+    label.textContent = 'Audio';
+    audioWrapper.appendChild(label);
+
+    const select = document.createElement('select');
+    select.className = 'phantomviews-audio-select';
+
+    validTracks.forEach((track, index) => {
+      const option = document.createElement('option');
+      option.value = track.url;
+      option.textContent = track.label || `Track ${index + 1}`;
+      select.appendChild(option);
+    });
+
+    const audio = document.createElement('audio');
+    audio.controls = true;
+    audio.preload = 'none';
+    audio.className = 'phantomviews-audio-player';
+    audio.src = validTracks[0].url;
+
+    select.value = validTracks[0].url;
+
+    select.addEventListener('change', (event) => {
+      audio.src = event.target.value;
+      audio.play().catch(() => {
+        /* playback may be blocked until user interaction */
+      });
+    });
+
+    audioWrapper.appendChild(select);
+    audioWrapper.appendChild(audio);
+    container.appendChild(audioWrapper);
+  };
+
+  const renderFloorPlans = (container, floorPlans = []) => {
+    const validPlans = floorPlans.filter((plan) => plan && plan.image_url);
+    if (!validPlans.length) {
+      return;
+    }
+
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'phantomviews-floorplan-toggle';
+    toggle.textContent = 'Floor plans';
+    toggle.setAttribute('aria-expanded', 'false');
+
+    const panel = document.createElement('div');
+    panel.className = 'phantomviews-floorplan-panel';
+    panel.setAttribute('aria-hidden', 'true');
+
+    validPlans.forEach((plan) => {
+      const item = document.createElement('figure');
+      item.className = 'phantomviews-floorplan-item';
+
+      const img = document.createElement('img');
+      img.src = plan.image_url;
+      img.alt = plan.title || 'Floor plan';
+      img.loading = 'lazy';
+
+      const caption = document.createElement('figcaption');
+      caption.textContent = plan.title || '';
+
+      item.appendChild(img);
+      if (caption.textContent) {
+        item.appendChild(caption);
+      }
+      panel.appendChild(item);
+    });
+
+    toggle.addEventListener('click', () => {
+      const isOpen = panel.classList.toggle('is-open');
+      toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+      panel.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+    });
+
+    container.appendChild(toggle);
+    container.appendChild(panel);
+  };
+
+  tours.forEach((container) => {
+    const tourId = container.dataset.tourId;
+    const dataScript = document.querySelector(`script.phantomviews-data[data-tour-id="${tourId}"]`);
+    if (!dataScript) {
+      return;
+    }
+
+    const tourData = parseTourData(dataScript.textContent);
+    const scenes = Array.isArray(tourData.scenes) ? tourData.scenes : [];
+
+    if (!scenes.length) {
+      return;
+    }
+
+    applyTheme(container, tourData.theme);
+    renderBranding(container, tourData.branding);
+    renderAudioControls(container, tourData.audioTracks);
+    renderFloorPlans(container, tourData.floorPlans);
+
+    const viewer = new PANOLENS.Viewer({
+      container: container.querySelector('.phantomviews-viewer'),
+      controlBar: true,
+      autoHideInfospot: false,
+    });
+
+    const sceneMap = new Map();
+
+    scenes.forEach((scene) => {
+      if (!scene || !scene.image_url) {
+        return;
+      }
+
+      const panorama = new PANOLENS.ImagePanorama(scene.image_url);
+
+      if (Array.isArray(scene.hotspots)) {
+        scene.hotspots.forEach((hotspot) => {
+          const infospot = new PANOLENS.Infospot(350, hotspot.icon_url || undefined);
+          if (hotspot.position) {
+            infospot.position.set(hotspot.position.x, hotspot.position.y, hotspot.position.z);
+          }
+
+          if (hotspot.type === 'link' && hotspot.target_scene && hotspot.target_scene !== scene.id) {
+            infospot.addHoverText(hotspot.title || '');
+            infospot.addEventListener('click', () => {
+              const target = sceneMap.get(hotspot.target_scene);
+              if (target) {
+                viewer.setPanorama(target.panorama);
+              }
+            });
+          }
+
+          if (hotspot.type === 'media' && hotspot.media_url) {
+            const iframe = document.createElement('iframe');
+            iframe.src = hotspot.media_url;
+            iframe.setAttribute('allowfullscreen', 'true');
+            iframe.classList.add('phantomviews-hotspot-media');
+            infospot.addHoverElement(iframe, 220);
+          } else if (hotspot.description) {
+            infospot.addHoverText(hotspot.description);
+          }
+
+          panorama.add(infospot);
+        });
+      }
+
+      sceneMap.set(scene.id, { panorama, scene });
+      viewer.add(panorama);
+    });
+
+    const initial = sceneMap.values().next().value;
+    if (initial) {
+      viewer.setPanorama(initial.panorama);
+    }
+  });
 })();

--- a/includes/class-phantomviews-post-types.php
+++ b/includes/class-phantomviews-post-types.php
@@ -98,14 +98,50 @@ __( 'PhantomViews Tour Builder', 'phantomviews' ),
  */
 public function render_tour_meta_box( $post ) {
 wp_nonce_field( 'phantomviews_save_tour', 'phantomviews_nonce' );
-$scenes = get_post_meta( $post->ID, '_phantomviews_scenes', true );
-if ( ! is_array( $scenes ) ) {
-$scenes = [];
-}
-$scene_limit = apply_filters( 'phantomviews_free_scene_limit', 3 );
-?>
-<div id="phantomviews-tour-root" data-post-id="<?php echo esc_attr( $post->ID ); ?>" data-scenes='<?php echo esc_attr( wp_json_encode( $scenes ) ); ?>' data-scene-limit="<?php echo esc_attr( $scene_limit ); ?>"></div>
-<?php
+        $scenes = get_post_meta( $post->ID, '_phantomviews_scenes', true );
+        if ( ! is_array( $scenes ) ) {
+            $scenes = [];
+        }
+
+        $branding = get_post_meta( $post->ID, '_phantomviews_branding', true );
+        if ( ! is_array( $branding ) ) {
+            $branding = [];
+        }
+
+        $theme = get_post_meta( $post->ID, '_phantomviews_theme', true );
+        if ( ! is_array( $theme ) ) {
+            $theme = [];
+        }
+
+        $expiration = get_post_meta( $post->ID, '_phantomviews_expiration', true );
+        if ( ! is_array( $expiration ) ) {
+            $expiration = [];
+        }
+
+        $floor_plans = get_post_meta( $post->ID, '_phantomviews_floor_plans', true );
+        if ( ! is_array( $floor_plans ) ) {
+            $floor_plans = [];
+        }
+
+        $audio_tracks = get_post_meta( $post->ID, '_phantomviews_audio_tracks', true );
+        if ( ! is_array( $audio_tracks ) ) {
+            $audio_tracks = [];
+        }
+
+        $scene_limit = apply_filters( 'phantomviews_free_scene_limit', 3 );
+        ?>
+        <div
+            id="phantomviews-tour-root"
+            data-post-id="<?php echo esc_attr( $post->ID ); ?>"
+            data-scenes='<?php echo esc_attr( wp_json_encode( $scenes ) ); ?>'
+            data-branding='<?php echo esc_attr( wp_json_encode( $branding ) ); ?>'
+            data-theme='<?php echo esc_attr( wp_json_encode( $theme ) ); ?>'
+            data-expiration='<?php echo esc_attr( wp_json_encode( $expiration ) ); ?>'
+            data-floor-plans='<?php echo esc_attr( wp_json_encode( $floor_plans ) ); ?>'
+            data-audio-tracks='<?php echo esc_attr( wp_json_encode( $audio_tracks ) ); ?>'
+            data-scene-limit="<?php echo esc_attr( $scene_limit ); ?>"
+        ></div>
+        <?php
 }
 
 /**

--- a/includes/class-phantomviews-rest.php
+++ b/includes/class-phantomviews-rest.php
@@ -90,8 +90,23 @@ if ( ! $tour_id || 'pv_tour' !== get_post_type( $tour_id ) ) {
 return new WP_REST_Response( [ 'message' => __( 'Invalid tour ID.', 'phantomviews' ) ], 400 );
 }
 
-$scenes = $request->get_param( 'scenes' );
-$scenes = is_array( $scenes ) ? recursive_sanitize( $scenes ) : [];
+        $scenes = $request->get_param( 'scenes' );
+        $scenes = is_array( $scenes ) ? recursive_sanitize( $scenes ) : [];
+
+        $branding = $request->get_param( 'branding' );
+        $branding = is_array( $branding ) ? recursive_sanitize( $branding ) : [];
+
+        $theme = $request->get_param( 'theme' );
+        $theme = is_array( $theme ) ? recursive_sanitize( $theme ) : [];
+
+        $expiration = $request->get_param( 'expiration' );
+        $expiration = is_array( $expiration ) ? recursive_sanitize( $expiration ) : [];
+
+        $floor_plans = $request->get_param( 'floorPlans' );
+        $floor_plans = is_array( $floor_plans ) ? recursive_sanitize( $floor_plans ) : [];
+
+        $audio_tracks = $request->get_param( 'audioTracks' );
+        $audio_tracks = is_array( $audio_tracks ) ? recursive_sanitize( $audio_tracks ) : [];
 
 $license_manager = License_Manager::instance();
 if ( ! $license_manager->has_pro_access() ) {
@@ -101,9 +116,14 @@ return new WP_REST_Response( [ 'message' => __( 'The selected plan allows fewer 
 }
 }
 
-update_post_meta( $tour_id, '_phantomviews_scenes', $scenes );
+        update_post_meta( $tour_id, '_phantomviews_scenes', $scenes );
+        update_post_meta( $tour_id, '_phantomviews_branding', $branding );
+        update_post_meta( $tour_id, '_phantomviews_theme', $theme );
+        update_post_meta( $tour_id, '_phantomviews_expiration', $expiration );
+        update_post_meta( $tour_id, '_phantomviews_floor_plans', $floor_plans );
+        update_post_meta( $tour_id, '_phantomviews_audio_tracks', $audio_tracks );
 
-return new WP_REST_Response( [ 'message' => __( 'Tour scenes saved successfully.', 'phantomviews' ) ], 200 );
+        return new WP_REST_Response( [ 'message' => __( 'Tour updated successfully.', 'phantomviews' ) ], 200 );
 }
 
 /**


### PR DESCRIPTION
## Summary
- extend the tour meta box, REST endpoint, and shortcode payload to support branding, theme, expiration, floor plan, and audio track metadata
- enhance the React-based tour builder with panels for white-label branding, custom themes, expirable links, multi-track audio, and unlimited floor plans
- refresh the front-end viewer to honor custom themes, surface branding badges, provide audio switching controls, and display toggleable floor plan overlays with updated styling

## Testing
- php -l includes/class-phantomviews-post-types.php
- php -l includes/class-phantomviews-rest.php
- php -l includes/class-phantomviews.php

------
https://chatgpt.com/codex/tasks/task_e_68cc875f48208327b6a97d9277678dc2